### PR TITLE
Created main CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,4 +13,4 @@ jobs:
     - name: Enable Developer Command Prompt
       uses: ilammy/msvc-dev-cmd@v1.0.0
     - name: Build
-      run: MSBuild.exe -t:Build -p:Configuration=Release -p:Platform=Win32 jkgfxmod.sln
+      run: MSBuild.exe -t:Build -p:Configuration=Release -p:Platform=x86 jkgfxmod.sln

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Enable Developer Command Prompt
+      uses: ilammy/msvc-dev-cmd@v1.0.0
+    - name: Build
+      run: MSBuild.exe -t:Build -p:Configuration=Release -p:Platform=Win32 jkgfxmod.sln


### PR DESCRIPTION
This commit introduces a trivial CI workflow (GitHub Actions). This workflow should build the code on push.

There doesn't appear to be any way to test these scripts without committing them, so this should be considered a provisional commit.