### PR TITLE
Fix deprecated actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,6 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
     - name: Enable Developer Command Prompt
-      uses: ilammy/msvc-dev-cmd@v1.0.0
+      uses: ilammy/msvc-dev-cmd@v1.4.1
     - name: Build
       run: MSBuild.exe -t:Build -p:Configuration=Release -p:Platform=x86 jkgfxmod.sln

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v1
       
     - name: Enable Developer Command Prompt
-      uses: ilammy/msvc-dev-cmd@v1.0.0
+      uses: ilammy/msvc-dev-cmd@v1.4.1
       
     - name: Build
       run: MSBuild.exe -t:Build -p:Configuration=Release -p:Platform=x86 jkgfxmod.sln


### PR DESCRIPTION
This change upgrades msvc-dev-cmd to the latest version. This change was necessary because GitHub deprecated some internal details of the original version.